### PR TITLE
fix message send box resize when typing in a message

### DIFF
--- a/app/src/pages/Messaging/SendMessage.tsx
+++ b/app/src/pages/Messaging/SendMessage.tsx
@@ -193,7 +193,7 @@ const SendMessage = (): JSX.Element => {
                         fontFamily: 'monospace',
                         width: 'calc(16ch + 2px)',
                         minHeight: 'calc(1em * 7)',
-                        height: 'auto',
+                        height: '178px',
                         resize: 'none',
                         padding: '5px',
                         lineHeight: '1',


### PR DESCRIPTION
the message send box would jitter when typing in a message, this make it stay one size as a message is being entered, until overflow